### PR TITLE
Changement de la profondeur des bits

### DIFF
--- a/library/vcl/display/opengl/texture/texture.cpp
+++ b/library/vcl/display/opengl/texture/texture.cpp
@@ -12,10 +12,10 @@ namespace vcl
 
         // Send texture on GPU
         if(im.color_type==image_color_type::rgba){
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA4, im.width, im.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, ptr(im.data)); opengl_check;
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, im.width, im.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, ptr(im.data)); opengl_check;
         }
         if(im.color_type==image_color_type::rgb){
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB4, im.width, im.height, 0, GL_RGB, GL_UNSIGNED_BYTE, ptr(im.data)); opengl_check;
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8, im.width, im.height, 0, GL_RGB, GL_UNSIGNED_BYTE, ptr(im.data)); opengl_check;
         }
         glGenerateMipmap(GL_TEXTURE_2D); opengl_check;
 

--- a/scenes/examples/04_classical_effects/01_environment_map/src/environment_map.cpp
+++ b/scenes/examples/04_classical_effects/01_environment_map/src/environment_map.cpp
@@ -17,12 +17,12 @@ GLuint cubemap_texture(std::string const& directory_path)
 	glGenTextures(1, &cubemap);
 	glBindTexture(GL_TEXTURE_CUBE_MAP, cubemap);
 
-	glTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_X, 0, GL_RGBA4, left.width, left.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, ptr(left.data));
-	glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X, 0, GL_RGBA4, right.width, right.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, ptr(right.data));
-	glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Y, 0, GL_RGBA4, top.width, top.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, ptr(top.data));
-	glTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Y, 0, GL_RGBA4, bottom.width, bottom.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, ptr(bottom.data));
-	glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Z, 0, GL_RGBA4, front.width, front.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, ptr(front.data));
-	glTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Z, 0, GL_RGBA4, back.width, back.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, ptr(back.data));
+	glTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_X, 0, GL_RGBA8, left.width, left.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, ptr(left.data));
+	glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_X, 0, GL_RGBA8, right.width, right.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, ptr(right.data));
+	glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Y, 0, GL_RGBA8, top.width, top.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, ptr(top.data));
+	glTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Y, 0, GL_RGBA8, bottom.width, bottom.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, ptr(bottom.data));
+	glTexImage2D(GL_TEXTURE_CUBE_MAP_POSITIVE_Z, 0, GL_RGBA8, front.width, front.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, ptr(front.data));
+	glTexImage2D(GL_TEXTURE_CUBE_MAP_NEGATIVE_Z, 0, GL_RGBA8, back.width, back.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, ptr(back.data));
 
 	glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_CUBE_MAP, GL_TEXTURE_MIN_FILTER, GL_LINEAR);


### PR DESCRIPTION
Changement de la profondeur des bits pour les textures de la vcl et la skybox de l'exemple

GL_RGBA4 permet de charger des textures sur 4 bits alors que GL_RGBA8 importe sur 8 bits